### PR TITLE
Modify state icons

### DIFF
--- a/frontend/src/components/Round.tsx
+++ b/frontend/src/components/Round.tsx
@@ -1,5 +1,6 @@
-import SolvedIcon from "@mui/icons-material/CheckRounded";
-import UnsolvedIcon from "@mui/icons-material/CloseRounded";
+import SolvedIcon from "@mui/icons-material/CheckBoxRounded";
+import UnsolvedIcon from "@mui/icons-material/DisabledByDefaultRounded";
+import BlankBoxIcon from "@mui/icons-material/CheckBoxOutlineBlankRounded";
 import DeleteIcon from "@mui/icons-material/UndoRounded";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -94,7 +95,6 @@ const Round: FC<Props> = ({ round, index }) => {
                     pt={1}
                     sx={{
                       textAlign: "center",
-
                       borderRadius:
                         query.verifier === "F"
                           ? theme.spacing(0, 0, 2, 0)
@@ -102,29 +102,16 @@ const Round: FC<Props> = ({ round, index }) => {
                     }}
                   >
                     <SingleCharLabel>{query.verifier}</SingleCharLabel>
-                    <Box pt={1} pb={2} position="relative">
-                      <Box
-                        height={20}
-                        margin="auto"
-                        width={20}
-                        sx={{
-                          borderWidth: 2,
-                          borderStyle: "solid",
-                          borderColor: theme.palette.primary.main,
-                          borderRadius: theme.spacing(0.5),
-                        }}
-                      />
-                      <Box
-                        position="absolute"
-                        top={-2}
-                        left={3}
-                        sx={{ color: theme.palette.text.primary }}
-                      >
+                    <Box position="relative">
+                      <Box>
+                        {query.state === "unknown" && (
+                          <BlankBoxIcon sx={{ color: theme.palette.primary.main }} />
+                        )}
                         {query.state === "solved" && (
-                          <SolvedIcon fontSize="large" />
+                          <SolvedIcon sx={{ color: theme.palette.primary.dark }} />
                         )}
                         {query.state === "unsolved" && (
-                          <UnsolvedIcon fontSize="large" />
+                          <UnsolvedIcon sx={{ color: theme.palette.secondary.dark }} />
                         )}
                       </Box>
                     </Box>


### PR DESCRIPTION
Instead of a plain check mark or cross use boxed icons with matching symbols.
Convert unknown state from div with border an empty box icon.
Instead of showing the state in black use primary.dark (green) and secondary.dark (red) as color for the state.

![grafik](https://github.com/alexander-zibert/turing-machine-board-game-solver/assets/63302676/37f58709-7d67-4389-9af1-3231f603c2f8)
