### PR TITLE
add switch to show, hide only possible numbers

### DIFF
--- a/frontend/src/components/PossibleCodes.tsx
+++ b/frontend/src/components/PossibleCodes.tsx
@@ -5,6 +5,8 @@ import { useAppSelector } from "hooks/useAppSelector";
 import { useEffect, useState } from "react";
 import { getPossibleCodes } from "deductions";
 import Collapse from "@mui/material/Collapse";
+import Paper from "@mui/material/Paper";
+import Box from "@mui/material/Box";
 
 function groupByFirst(codes: string[]) {
   const result: { [key: number]: { code: string; possible: boolean }[] } = {
@@ -30,9 +32,14 @@ export function PossibleCodes() {
 
   const [possibleCodes, setPossibleCodes] = useState(groupByFirst([]));
   const [expanded, setExpanded] = useState(false);
+  const [hide, setHide] = useState(false);
 
   function toggleExpanded() {
     setExpanded(!expanded);
+  }
+
+  function toggleHidden() {
+    setHide(!hide);
   }
 
   const comments = useAppSelector((state) => state.comments);
@@ -43,30 +50,41 @@ export function PossibleCodes() {
   }, [comments]);
 
   return (
-    <>
-      <Button onClick={toggleExpanded}>
-        {expanded ? "Hide code list" : "Show code list"}
-      </Button>
-      <Collapse in={expanded}>
-        <Grid container spacing={8}>
-          {[1, 2, 3, 4, 5].map((number) => (
-            <Grid item xs={2}>
-              {possibleCodes[number].map(({ code, possible }) => (
-                <div
-                  key={code}
-                  style={{
-                    color: possible
-                      ? theme.palette.text.primary
-                      : theme.palette.text.disabled,
-                  }}
-                >
-                  {code}
-                </div>
-              ))}
-            </Grid>
-          ))}
-        </Grid>
-      </Collapse>
-    </>
+    <Paper
+      component="section"
+      id="possible-codes-section"
+      sx={{ width: 320, margin: theme.spacing(0, "auto", 2) }}
+    >
+      <Box p={2} mt={2}>
+
+        <Button onClick={toggleExpanded}>
+          {expanded ? "Hide code list" : "Show code list"}
+        </Button>
+        <Collapse in={expanded}>
+          <Button onClick={toggleHidden}>
+            {hide ? "Show impossibles" : "Hide impossibles"}
+          </Button>
+          <Grid container spacing={8}>
+            {[1, 2, 3, 4, 5].map((number) => (
+              <Grid item xs={2} key={number}>
+                {possibleCodes[number].map(({code, possible}) => (
+                  <Grid item xs={2}
+                        hidden={!possible && hide}
+                        key={code}
+                        style={{
+                          color: possible
+                            ? theme.palette.text.primary
+                            : theme.palette.text.disabled,
+                        }}
+                  >
+                    {code}
+                  </Grid>
+                ))}
+              </Grid>
+            ))}
+          </Grid>
+        </Collapse>
+      </Box>
+    </Paper>
   );
 }


### PR DESCRIPTION
Just a suggestion:
Add `<Paper>` and `<Box>` to have the same UI
Add a button to show hide the possible numbers, I'd like to have this button to the right of the Show /Hide Code List and maybe only an icon / symbol. I've no idea which to choose. 
I've also replaced the `div` by  `Grid item` and added a missing key.

It's just a quick hack for the moment