### PR TITLE
remove undefined from verifier cards

### DIFF
--- a/frontend/src/components/TMInput.tsx
+++ b/frontend/src/components/TMInput.tsx
@@ -552,7 +552,7 @@ export type VerifierCard = {
 
 const verifierCards = (() => {
   const cards: VerifierCard[] = [];
-  CHECK_CARDS.forEach((value, color) => value.forEach((value) =>
-    cards.push({colorId: color, cryptId: value} as VerifierCard)));
+  CHECK_CARDS.forEach((value, color) => value.filter(value => value)
+    .forEach((value) => cards.push({colorId: color, cryptId: value} as VerifierCard)));
   return cards;
 })();


### PR DESCRIPTION
![grafik](https://github.com/alexander-zibert/turing-machine-board-game-solver/assets/63302676/19011f4f-3756-4895-ae1f-fbc6aa73ebe8)

Due to your changes there's an `undefined` valuefor each type of Verifier in the Verifier Cards drop down.  I've added a filter to remove that value from input.