### PR TITLE
configure TextField as number input to have a better UX on mobile dev…

### DIFF
--- a/frontend/src/components/TMInput.tsx
+++ b/frontend/src/components/TMInput.tsx
@@ -190,7 +190,23 @@ const CardInput: FC<CardInputProps> = (props) => {
         }
       }}
       renderInput={(params) => (
-        <MuiTextField {...params} />
+        <MuiTextField {...params} type={"number"} sx={{
+          // set type to number, to show number input on mobiles,
+          // and remove the spinners on input via css
+          input: {
+            "&[type=number]": {
+              "-moz-appearance": "textfield",
+            },
+            "&::-webkit-outer-spin-button": {
+              "-webkit-appearance": "none",
+              margin: 0,
+            },
+            "&::-webkit-inner-spin-button": {
+              "-webkit-appearance": "none",
+              margin: 0,
+            },
+          },
+        }} />
       )}
       ChipProps={{
         sx: {


### PR DESCRIPTION
…ices

- remove up/down spinner because it doesn't make sense on input for verification cards
- input is now shown as numbers only input on mobile devices